### PR TITLE
fix lookup bug

### DIFF
--- a/papertalk/models/articles.py
+++ b/papertalk/models/articles.py
@@ -77,7 +77,7 @@ def get_or_insert(articles):
             res[_id] = our_article
         else:
             _id = save(**a)
-            res[_id] = a
+            res[_id] = lookup(_id=_id)
 
     return res.values()
 

--- a/papertalk/utils/__init__.py
+++ b/papertalk/utils/__init__.py
@@ -48,7 +48,7 @@ def canonicalize(title):
         """
         normalizes given string for the canonicalization
         """
-        if not isinstance(s, str):
+        if not isinstance(s, basestring):
             return ''
 
         res = s.lower().strip() ## lowercase and remove outer spaced


### PR DESCRIPTION
There were two issues:
- canonicalization was expecting a plain string, and choked on unicode
- the _id is not after a save. now I'm doing the lookup afterward, which works but is wasteful

Should fix #37 
