### PR TITLE
Enh/sentry

### DIFF
--- a/papertalk/server.py
+++ b/papertalk/server.py
@@ -5,6 +5,7 @@ from flask_login import LoginManager, current_user, login_user
 from flask_sslify import SSLify
 import os
 from flask_oauthlib.client import OAuth
+from raven.contrib.flask import Sentry
 
 
 def init_login(app):
@@ -103,6 +104,7 @@ def make_app():
     app.secret_key = app.config['SECRET_KEY']
     #app.config['DEBUG'] = os.environ.get('DEBUG', True)
     app.session_cookie_name = "session"
+    sentry = Sentry(app)
 
 
     # Function to easily find your assets

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ disqus-python
 google-api-python-client
 gevent
 redis
+raven>=3
+blinker


### PR DESCRIPTION
- enabled sentry free plan on heroku; may need to upgrade to paid plan to add additional team members
- adds sentry client "raven" to requirements
- configures the app to automatically report uncaught exceptions

Event stream is here: https://app.getsentry.com/papertalk/papertalk/
Web interface can be accessed via `heroku addons:open sentry`
